### PR TITLE
Refactor stridingMemcpyKernel to be unroll friendly

### DIFF
--- a/library/kernels.cu
+++ b/library/kernels.cu
@@ -71,34 +71,32 @@ __global__ void stridingMemcpyKernel(unsigned int totalThreadCount, unsigned lon
     size_t globalThreadId = blockDim.x * blockIdx.x + threadIdx.x;
     dst += globalThreadId;
     src += globalThreadId;
+    size_t maxElementIndex = sizeInElement - globalThreadId;
 
     // Calculate where to end the big pipelined copy
     size_t bigChunkSizeInElement = chunkSizeInElement / UNROLL_FACTOR;
-    T *dstBigEnd = dst + (bigChunkSizeInElement * UNROLL_FACTOR) * totalThreadCount;
-
     for (unsigned int i = 0; i < loopCount; i++) {
-        T* cdst = dst;
-        T* csrc = src;
+        for (unsigned long long j = 0; j < bigChunkSizeInElement; j++) {
+            unsigned long long offset = j * UNROLL_FACTOR * totalThreadCount;
 
-        while (cdst < dstBigEnd) {
             T pipe[UNROLL_FACTOR];
             #pragma unroll
             for (int k = 0; k < UNROLL_FACTOR; ++k) {
-                pipe[k] = *csrc; csrc += totalThreadCount;
+                pipe[k] = src[offset + k * totalThreadCount];
             }
             #pragma unroll
             for (int k = 0; k < UNROLL_FACTOR; ++k) {
-                write(cdst, pipe[k]); cdst += totalThreadCount;
+                write(dst + offset + k * totalThreadCount, pipe[k]);
             }
         }
 
-        // Take care of copies that didn't get aligned properly
-        for (size_t j = bigChunkSizeInElement * UNROLL_FACTOR; j < chunkSizeInElement; ++j) {
-            write(dst + j * totalThreadCount, src[j * totalThreadCount]);
+        // Take care of copies that didn't get aligned properly and remainder elements
+        size_t start_offset = bigChunkSizeInElement * UNROLL_FACTOR * totalThreadCount;
+        for (size_t offset = start_offset; offset < maxElementIndex; offset += totalThreadCount) {
+            write(dst + offset, src[offset]);
         }
     }
 }
-
 
 template<typename T, reduce_from_memory<T> write>
 __global__ void simpleMemcpyKernel(unsigned int totalThreadCount, unsigned long long loopCount, T* dst, T* src, size_t sizeInElement) {

--- a/library/kernels.cu
+++ b/library/kernels.cu
@@ -38,6 +38,11 @@ __device__ void write_to_regular_memory(T *dst, T val) {
     *dst = val;
 }
 
+template<>
+__device__ void write_to_regular_memory<uint4>(uint4 *dst, uint4 val) {
+    *dst = {val.x, val.y, val.z, val.w};
+}
+
 template<typename T>
 __device__ void write_to_multicast_memory(T *dst, T val) {
 #if __CUDA_ARCH__ >= 900
@@ -59,9 +64,8 @@ __device__ void reduce_from_multicast_red(T *dst, T *val) {
 #endif
 }
 
-template<typename T, write_to_memory<T> write>
+template<typename T, write_to_memory<T> write, int UNROLL_FACTOR = 12>
 __global__ void stridingMemcpyKernel(unsigned int totalThreadCount, unsigned long long loopCount, T* dst, T* src, size_t sizeInElement) {
-    T *dstEnd = dst + sizeInElement;
     size_t chunkSizeInElement = sizeInElement / totalThreadCount;
 
     size_t globalThreadId = blockDim.x * blockIdx.x + threadIdx.x;
@@ -69,47 +73,32 @@ __global__ void stridingMemcpyKernel(unsigned int totalThreadCount, unsigned lon
     src += globalThreadId;
 
     // Calculate where to end the big pipelined copy
-    size_t bigChunkSizeInElement = chunkSizeInElement / 12;
-    T *dstBigEnd = dst + (bigChunkSizeInElement * 12) * totalThreadCount;
+    size_t bigChunkSizeInElement = chunkSizeInElement / UNROLL_FACTOR;
+    T *dstBigEnd = dst + (bigChunkSizeInElement * UNROLL_FACTOR) * totalThreadCount;
 
     for (unsigned int i = 0; i < loopCount; i++) {
         T* cdst = dst;
         T* csrc = src;
 
         while (cdst < dstBigEnd) {
-            T pipe_0 = *csrc; csrc += totalThreadCount;
-            T pipe_1 = *csrc; csrc += totalThreadCount;
-            T pipe_2 = *csrc; csrc += totalThreadCount;
-            T pipe_3 = *csrc; csrc += totalThreadCount;
-            T pipe_4 = *csrc; csrc += totalThreadCount;
-            T pipe_5 = *csrc; csrc += totalThreadCount;
-            T pipe_6 = *csrc; csrc += totalThreadCount;
-            T pipe_7 = *csrc; csrc += totalThreadCount;
-            T pipe_8 = *csrc; csrc += totalThreadCount;
-            T pipe_9 = *csrc; csrc += totalThreadCount;
-            T pipe_10 = *csrc; csrc += totalThreadCount;
-            T pipe_11 = *csrc; csrc += totalThreadCount;
-
-            write(cdst, pipe_0); cdst += totalThreadCount;
-            write(cdst, pipe_1); cdst += totalThreadCount;
-            write(cdst, pipe_2); cdst += totalThreadCount;
-            write(cdst, pipe_3); cdst += totalThreadCount;
-            write(cdst, pipe_4); cdst += totalThreadCount;
-            write(cdst, pipe_5); cdst += totalThreadCount;
-            write(cdst, pipe_6); cdst += totalThreadCount;
-            write(cdst, pipe_7); cdst += totalThreadCount;
-            write(cdst, pipe_8); cdst += totalThreadCount;
-            write(cdst, pipe_9); cdst += totalThreadCount;
-            write(cdst, pipe_10); cdst += totalThreadCount;
-            write(cdst, pipe_11); cdst += totalThreadCount;
+            T pipe[UNROLL_FACTOR];
+            #pragma unroll
+            for (int k = 0; k < UNROLL_FACTOR; ++k) {
+                pipe[k] = *csrc; csrc += totalThreadCount;
+            }
+            #pragma unroll
+            for (int k = 0; k < UNROLL_FACTOR; ++k) {
+                write(cdst, pipe[k]); cdst += totalThreadCount;
+            }
         }
 
         // Take care of copies that didn't get aligned properly
-        while (cdst < dstEnd) {
-            write(cdst, *csrc); cdst += totalThreadCount; csrc += totalThreadCount;
+        for (size_t j = bigChunkSizeInElement * UNROLL_FACTOR; j < chunkSizeInElement; ++j) {
+            write(dst + j * totalThreadCount, src[j * totalThreadCount]);
         }
     }
 }
+
 
 template<typename T, reduce_from_memory<T> write>
 __global__ void simpleMemcpyKernel(unsigned int totalThreadCount, unsigned long long loopCount, T* dst, T* src, size_t sizeInElement) {


### PR DESCRIPTION
This is a port of the changes to the same kernel in nvbandwidth: https://github.com/NVIDIA/nvbandwidth/pull/65
